### PR TITLE
Makes datasource configurable on import of dashboard

### DIFF
--- a/GFAAppliances.json
+++ b/GFAAppliances.json
@@ -1,4 +1,41 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_MYINFLUXDB",
+      "label": "MYINFLUXDB",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "influxdb",
+      "pluginName": "InfluxDB"
+    }
+  ],
+  "__elements": [],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "8.4.3"
+    },
+    {
+      "type": "datasource",
+      "id": "influxdb",
+      "name": "InfluxDB",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -22,8 +59,8 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 3,
-  "iteration": 1649686455357,
+  "id": null,
+  "iteration": 1652985339839,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -95,19 +132,14 @@
           "show": false
         },
         "showHeader": true,
-        "sortBy": [
-          {
-            "desc": false,
-            "displayName": "filer_title"
-          }
-        ]
+        "sortBy": []
       },
       "pluginVersion": "8.4.3",
       "targets": [
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "PB6B4F2F1C736D27A"
+            "uid": "${DS_MYINFLUXDB}"
           },
           "groupBy": [
             {
@@ -222,7 +254,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "PB6B4F2F1C736D27A"
+            "uid": "${DS_MYINFLUXDB}"
           },
           "groupBy": [
             {
@@ -378,7 +410,7 @@
           "alias": "$col",
           "datasource": {
             "type": "influxdb",
-            "uid": "PB6B4F2F1C736D27A"
+            "uid": "${DS_MYINFLUXDB}"
           },
           "groupBy": [
             {
@@ -423,7 +455,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 84
+        "y": 69
       },
       "id": 16,
       "panels": [],
@@ -527,7 +559,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 85
+        "y": 70
       },
       "id": 12,
       "maxPerRow": 2,
@@ -549,7 +581,7 @@
           "alias": "$col",
           "datasource": {
             "type": "influxdb",
-            "uid": "PB6B4F2F1C736D27A"
+            "uid": "${DS_MYINFLUXDB}"
           },
           "groupBy": [
             {
@@ -614,7 +646,7 @@
           "alias": "$col",
           "datasource": {
             "type": "influxdb",
-            "uid": "PB6B4F2F1C736D27A"
+            "uid": "${DS_MYINFLUXDB}"
           },
           "groupBy": [
             {
@@ -690,15 +722,7 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "selected": true,
-          "text": [
-            "All"
-          ],
-          "value": [
-            "$__all"
-          ]
-        },
+        "current": {},
         "definition": "SELECT distinct(volume_title) FROM (\nSELECT * \nFROM \"gfa_data\" \nWHERE $timeFilter \n)",
         "description": "",
         "hide": 0,
@@ -712,14 +736,11 @@
         "regex": "",
         "skipUrlSync": false,
         "sort": 5,
-        "type": "query"
+        "type": "query",
+        "datasource": "${DS_MYINFLUXDB}"
       },
       {
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
+        "current": {},
         "definition": "SELECT distinct(filer_title) FROM (\nSELECT * \nFROM \"gfa_data\" \nWHERE $timeFilter \n)",
         "description": "",
         "hide": 0,
@@ -733,7 +754,8 @@
         "regex": "",
         "skipUrlSync": false,
         "sort": 5,
-        "type": "query"
+        "type": "query",
+        "datasource": "${DS_MYINFLUXDB}"
       }
     ]
   },
@@ -745,6 +767,6 @@
   "timezone": "",
   "title": "GFA :: Appliances",
   "uid": "9iFmEGL7z",
-  "version": 4,
+  "version": 5,
   "weekStart": ""
 }

--- a/GFAVolumes.json
+++ b/GFAVolumes.json
@@ -1,4 +1,47 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_SOMEOTHERNAME",
+      "label": "SOMEOTHERNAME",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "influxdb",
+      "pluginName": "InfluxDB"
+    }
+  ],
+  "__elements": [],
+  "__requires": [
+    {
+      "type": "panel",
+      "id": "candlestick",
+      "name": "Candlestick",
+      "version": ""
+    },
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "8.4.1"
+    },
+    {
+      "type": "datasource",
+      "id": "influxdb",
+      "name": "InfluxDB",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "state-timeline",
+      "name": "State timeline",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -21,234 +64,12 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 4,
-  "iteration": 1647351320854,
+  "id": null,
+  "iteration": 1652963964447,
   "links": [],
   "liveNow": false,
   "panels": [
     {
-      "description": "Number of all active appliances grouped by volume",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "green",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 8,
-        "x": 0,
-        "y": 0
-      },
-      "id": 50,
-      "options": {
-        "colorMode": "none",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^gfa_data\\.count$/",
-          "values": true
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "8.4.3",
-      "targets": [
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "PB6B4F2F1C736D27A"
-          },
-          "groupBy": [],
-          "measurement": "gfa_data",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT COUNT(DISTINCT filer_title)\nFROM (SELECT \"filer_title\", \"last_checkin\" FROM \"gfa_data\" WHERE $timeFilter GROUP BY \"volume_title\")",
-          "rawQuery": true,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "mode"
-                ],
-                "type": "field"
-              }
-            ]
-          ],
-          "tags": []
-        }
-      ],
-      "title": "Active appliances",
-      "type": "stat"
-    },
-    {
-      "description": "GFA State: can be either Active, Observation, or Disabled",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "green",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 8,
-        "x": 8,
-        "y": 0
-      },
-      "id": 39,
-      "options": {
-        "colorMode": "none",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "vertical",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^mode$/",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "8.4.3",
-      "targets": [
-        {
-          "alias": "$col",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "PB6B4F2F1C736D27A"
-          },
-          "groupBy": [],
-          "measurement": "gfa_data",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT \"mode\"  FROM \"gfa_data\" WHERE $timeFilter GROUP BY \"volume_title\"",
-          "rawQuery": true,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "mode"
-                ],
-                "type": "field"
-              }
-            ]
-          ],
-          "tags": []
-        }
-      ],
-      "title": "Configuration: mode",
-      "type": "stat"
-    },
-    {
-      "description": "GFA profile: can be one of data-protect-only, data-protect-moderate, default (no preference), collaboration-moderate, collaboration-only",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "green",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 8,
-        "x": 16,
-        "y": 0
-      },
-      "id": 49,
-      "options": {
-        "colorMode": "none",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^profile$/",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "8.4.3",
-      "targets": [
-        {
-          "alias": "$col",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "PB6B4F2F1C736D27A"
-          },
-          "groupBy": [],
-          "measurement": "gfa_data",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT \"profile\" FROM \"gfa_data\" WHERE $timeFilter GROUP BY \"volume_title\"",
-          "rawQuery": true,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "mode"
-                ],
-                "type": "field"
-              }
-            ]
-          ],
-          "tags": []
-        }
-      ],
-      "title": "Configuration: profile",
-      "type": "stat"
-    },
-    {
-      "description": "Data propagation times by volume, times plotted are minimum, 25th, 50th(median), 75th, and 99th(max) percentiles",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -298,13 +119,13 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "median"
+              "options": "gfa_data.Median"
             },
             "properties": [
               {
                 "id": "color",
                 "value": {
-                  "fixedColor": "super-light-blue",
+                  "fixedColor": "super-light-green",
                   "mode": "fixed"
                 }
               },
@@ -334,7 +155,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 3
+        "y": 0
       },
       "id": 47,
       "options": {
@@ -342,13 +163,13 @@
         "colorStrategy": "open-close",
         "colors": {
           "down": "red",
-          "up": "blue"
+          "up": "green"
         },
         "fields": {
-          "close": "75%",
-          "high": "max",
-          "low": "min",
-          "open": "25%"
+          "close": "gfa_data.75%",
+          "high": "gfa_data.Max",
+          "low": "gfa_data.Min",
+          "open": "gfa_data.25%"
         },
         "includeAllFields": true,
         "legend": {
@@ -360,15 +181,14 @@
       },
       "targets": [
         {
-          "alias": "$col",
           "datasource": {
             "type": "influxdb",
-            "uid": "PB6B4F2F1C736D27A"
+            "uid": "${DS_SOMEOTHERNAME}"
           },
           "groupBy": [
             {
               "params": [
-                "$group_by_interval"
+                "1h"
               ],
               "type": "time"
             }
@@ -434,7 +254,7 @@
               },
               {
                 "params": [
-                  "min"
+                  "Min"
                 ],
                 "type": "alias"
               }
@@ -447,14 +267,12 @@
                 "type": "field"
               },
               {
-                "params": [
-                  "99"
-                ],
-                "type": "percentile"
+                "params": [],
+                "type": "max"
               },
               {
                 "params": [
-                  "max"
+                  "Max"
                 ],
                 "type": "alias"
               }
@@ -469,15 +287,14 @@
           ]
         },
         {
-          "alias": "$col",
           "datasource": {
             "type": "influxdb",
-            "uid": "PB6B4F2F1C736D27A"
+            "uid": "${DS_SOMEOTHERNAME}"
           },
           "groupBy": [
             {
               "params": [
-                "$group_by_interval"
+                "1h"
               ],
               "type": "time"
             },
@@ -510,7 +327,7 @@
               },
               {
                 "params": [
-                  "median"
+                  "Median"
                 ],
                 "type": "alias"
               }
@@ -523,12 +340,10 @@
       "type": "candlestick"
     },
     {
-      "description": "Average age of unprotected data per volume",
       "fieldConfig": {
         "defaults": {
           "color": {
-            "fixedColor": "green",
-            "mode": "fixed"
+            "mode": "palette-classic"
           },
           "custom": {
             "axisLabel": "",
@@ -619,10 +434,10 @@
         ]
       },
       "gridPos": {
-        "h": 9,
+        "h": 6,
         "w": 24,
         "x": 0,
-        "y": 13
+        "y": 10
       },
       "id": 11,
       "options": {
@@ -638,15 +453,14 @@
       },
       "targets": [
         {
-          "alias": "event age",
           "datasource": {
             "type": "influxdb",
-            "uid": "PB6B4F2F1C736D27A"
+            "uid": "${DS_SOMEOTHERNAME}"
           },
           "groupBy": [
             {
               "params": [
-                "$group_by_interval"
+                "5m"
               ],
               "type": "time"
             },
@@ -672,7 +486,7 @@
               },
               {
                 "params": [],
-                "type": "mean"
+                "type": "max"
               },
               {
                 "params": [
@@ -685,17 +499,15 @@
           "tags": []
         }
       ],
-      "title": "Average oldest unprotected data",
+      "title": "Oldest Unprotected Data",
       "transparent": true,
       "type": "timeseries"
     },
     {
-      "description": "Number of file system events  protected corresponding to the propagation times above ",
       "fieldConfig": {
         "defaults": {
           "color": {
-            "fixedColor": "purple",
-            "mode": "fixed"
+            "mode": "palette-classic"
           },
           "custom": {
             "axisLabel": "",
@@ -730,8 +542,12 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "purple",
+                "color": "green",
                 "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
               }
             ]
           },
@@ -740,10 +556,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
+        "h": 6,
         "w": 24,
         "x": 0,
-        "y": 22
+        "y": 16
       },
       "id": 48,
       "options": {
@@ -759,15 +575,14 @@
       },
       "targets": [
         {
-          "alias": "$col",
           "datasource": {
             "type": "influxdb",
-            "uid": "PB6B4F2F1C736D27A"
+            "uid": "${DS_SOMEOTHERNAME}"
           },
           "groupBy": [
             {
               "params": [
-                "$group_by_interval"
+                "5m"
               ],
               "type": "time"
             },
@@ -798,7 +613,7 @@
               },
               {
                 "params": [
-                  "audit events"
+                  "writes"
                 ],
                 "type": "alias"
               }
@@ -812,7 +627,6 @@
       "type": "timeseries"
     },
     {
-      "description": "Amount of time volume lock held by all appliances",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -827,14 +641,14 @@
             {
               "options": {
                 "ACQUIRED": {
-                  "color": "dark-blue",
+                  "color": "blue",
                   "index": 0,
-                  "text": "locked"
+                  "text": "Locked"
                 },
                 "RELEASED": {
-                  "color": "#00000000",
+                  "color": "transparent",
                   "index": 1,
-                  "text": "unlocked"
+                  "text": "Unlocked"
                 }
               },
               "type": "value"
@@ -856,7 +670,7 @@
         "h": 5,
         "w": 24,
         "x": 0,
-        "y": 29
+        "y": 22
       },
       "id": 41,
       "options": {
@@ -875,16 +689,15 @@
       },
       "targets": [
         {
-          "alias": "$col",
           "datasource": {
             "type": "influxdb",
-            "uid": "PB6B4F2F1C736D27A"
+            "uid": "${DS_SOMEOTHERNAME}"
           },
           "groupBy": [],
           "measurement": "gfa_data",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT \"lock_state\" as \"lock\"  FROM \"gfa_data\" WHERE (\"volume_title\" =~ /^$volume$/) AND $timeFilter AND (\"lock_state\" = 'ACQUIRED' OR \"lock_state\" = 'RELEASED')",
+          "query": "SELECT \"lock_state\" FROM \"gfa_data\" WHERE (\"volume_title\" =~ /^$volume$/) AND $timeFilter AND (\"lock_state\" = 'ACQUIRED' OR \"lock_state\" = 'RELEASED')",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series",
@@ -907,27 +720,110 @@
           ]
         }
       ],
-      "title": "Lock Utilization",
+      "title": "Lock Usage",
       "transparent": true,
+      "type": "state-timeline"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "green",
+            "mode": "fixed"
+          },
+          "custom": {
+            "fillOpacity": 50,
+            "lineWidth": 1,
+            "spanNulls": false
+          },
+          "mappings": [
+            {
+              "options": {
+                "Active": {
+                  "color": "green",
+                  "index": 0
+                },
+                "Observation": {
+                  "color": "yellow",
+                  "index": 1
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
+      "id": 39,
+      "options": {
+        "alignValue": "left",
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "mergeValues": true,
+        "rowHeight": 0.57,
+        "showValue": "auto",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_SOMEOTHERNAME}"
+          },
+          "groupBy": [],
+          "measurement": "gfa_data",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT \"mode\", \"profile\", \"time_to_protect\" FROM \"gfa_data\" WHERE $timeFilter GROUP BY \"volume_title\"",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "mode"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Appliance File Accelerator State",
       "type": "state-timeline"
     }
   ],
-  "refresh": "",
+  "refresh": "1m",
   "schemaVersion": 35,
   "style": "dark",
   "tags": [],
   "templating": {
     "list": [
       {
-        "current": {
-          "selected": true,
-          "text": [
-            "All"
-          ],
-          "value": [
-            "$__all"
-          ]
-        },
+        "current": {},
         "definition": "SELECT distinct(volume_title) FROM (\nSELECT * \nFROM \"gfa_data\" \nWHERE $timeFilter \n)",
         "description": "",
         "hide": 0,
@@ -941,78 +837,8 @@
         "regex": "",
         "skipUrlSync": false,
         "sort": 5,
-        "type": "query"
-      },
-      {
-        "auto": false,
-        "auto_count": 30,
-        "auto_min": "10s",
-        "current": {
-          "selected": false,
-          "text": "1h",
-          "value": "1h"
-        },
-        "description": "Time range by which to group data points",
-        "hide": 0,
-        "label": "Group by",
-        "name": "group_by_interval",
-        "options": [
-          {
-            "selected": false,
-            "text": "5m",
-            "value": "5m"
-          },
-          {
-            "selected": false,
-            "text": "15m",
-            "value": "15m"
-          },
-          {
-            "selected": false,
-            "text": "30m",
-            "value": "30m"
-          },
-          {
-            "selected": true,
-            "text": "1h",
-            "value": "1h"
-          },
-          {
-            "selected": false,
-            "text": "2h",
-            "value": "2h"
-          },
-          {
-            "selected": false,
-            "text": "3h",
-            "value": "3h"
-          },
-          {
-            "selected": false,
-            "text": "6h",
-            "value": "6h"
-          },
-          {
-            "selected": false,
-            "text": "12h",
-            "value": "12h"
-          },
-          {
-            "selected": false,
-            "text": "1d",
-            "value": "1d"
-          },
-          {
-            "selected": false,
-            "text": "7d",
-            "value": "7d"
-          }
-        ],
-        "query": "5m,15m,30m,1h,2h,3h,6h,12h,1d,7d",
-        "queryValue": "",
-        "refresh": 2,
-        "skipUrlSync": false,
-        "type": "interval"
+        "type": "query",
+        "datasource": "${DS_SOMEOTHERNAME}"
       }
     ]
   },
@@ -1024,6 +850,6 @@
   "timezone": "",
   "title": "GFA :: Volumes",
   "uid": "60XLPNL7z",
-  "version": 18,
+  "version": 1,
   "weekStart": ""
 }


### PR DESCRIPTION
The GFA dashboards had been exported for "internal" sharing which can cause issues when they are loaded into a different Grafana server where the datasource name/UID does not match the dashboards. We failed to see this locally because we deploy the dashboards via provisioning rather than importing them.

This change updates them with versions that have been exported "for sharing externally", which means when they are imported the user will be given a change to select the datasource to use with the dashboard. (As outlined in step four of the "Configure Grafana Dashboards" section in the README.

You can see this in the screenshot below, while importing the new GFA Volumes dashboard,
<img width="1713" alt="Screen Shot 2022-05-19 at 2 34 29 PM" src="https://user-images.githubusercontent.com/75635996/169377972-dd0e95d6-cad3-48a6-91c6-0dd2bdfbbd42.png">

