### PR TITLE
Minor fixes to the GFA dashboards

### DIFF
--- a/GFAAppliances.json
+++ b/GFAAppliances.json
@@ -60,7 +60,7 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1653068605768,
+  "iteration": 1653310450843,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -455,7 +455,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 109
+        "y": 79
       },
       "id": 16,
       "panels": [],
@@ -559,7 +559,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 110
+        "y": 80
       },
       "id": 12,
       "maxPerRow": 2,
@@ -773,6 +773,6 @@
   "timezone": "",
   "title": "GFA :: Appliances",
   "uid": "9iFmEGL7z",
-  "version": 4,
+  "version": 2,
   "weekStart": ""
 }

--- a/GFAMiscellaneous.json
+++ b/GFAMiscellaneous.json
@@ -9,6 +9,45 @@
       "pluginName": "InfluxDB"
     }
   ],
+  "__elements": [],
+  "__requires": [
+    {
+      "type": "panel",
+      "id": "bargauge",
+      "name": "Bar gauge",
+      "version": ""
+    },
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "8.4.1"
+    },
+    {
+      "type": "datasource",
+      "id": "influxdb",
+      "name": "InfluxDB",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "state-timeline",
+      "name": "State timeline",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -31,8 +70,8 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 3,
-  "iteration": 1653073145012,
+  "id": null,
+  "iteration": 1653310463740,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -1070,11 +1109,7 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "selected": false,
-          "text": "UKVolume1",
-          "value": "UKVolume1"
-        },
+        "current": {},
         "definition": "SELECT distinct(volume_title) FROM (\nSELECT * \nFROM \"gfa_data\" \nWHERE $timeFilter \n)",
         "hide": 0,
         "includeAll": false,
@@ -1087,18 +1122,11 @@
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
-        "type": "query"
+        "type": "query",
+        "datasource": "${DS_INFLUXDB}"
       },
       {
-        "current": {
-          "selected": true,
-          "text": [
-            "All"
-          ],
-          "value": [
-            "$__all"
-          ]
-        },
+        "current": {},
         "definition": "SELECT distinct(filer_title) FROM (\nSELECT * \nFROM \"gfa_data\" \nWHERE $timeFilter  AND (\"volume_title\" =~ /^$volume$/)\n)",
         "hide": 0,
         "includeAll": true,
@@ -1111,7 +1139,8 @@
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
-        "type": "query"
+        "type": "query",
+        "datasource": "${DS_INFLUXDB}"
       }
     ]
   },
@@ -1123,6 +1152,6 @@
   "timezone": "",
   "title": "GFA :: Miscellaneous",
   "uid": "XQyncEL7k",
-  "version": 7,
+  "version": 2,
   "weekStart": ""
 }

--- a/GFAVolumes.json
+++ b/GFAVolumes.json
@@ -65,7 +65,7 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1653056328351,
+  "iteration": 1653310430753,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -565,32 +565,7 @@
           },
           "unit": "none"
         },
-        "overrides": [
-          {
-            "__systemRef": "hideSeriesFrom",
-            "matcher": {
-              "id": "byNames",
-              "options": {
-                "mode": "exclude",
-                "names": [
-                  "gfa_data.writes {volume_title: USVolume2}"
-                ],
-                "prefix": "All except:",
-                "readOnly": true
-              }
-            },
-            "properties": [
-              {
-                "id": "custom.hideFrom",
-                "value": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": true
-                }
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
         "h": 6,
@@ -889,7 +864,7 @@
     ]
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-7d",
     "to": "now"
   },
   "timepicker": {},


### PR DESCRIPTION
The "Audit Event Counts" panel on the "GFA Volumes" dashboard had an override set to limit the results to a non-existent volume, causing the panel to render no data by default. This change also sets the default time range to last 7 days for the "GFA Volumes" dashboard.