### PR TITLE
Adds GFA Time Between P2s dashboard

### DIFF
--- a/GFATimeBetweenP2s.json
+++ b/GFATimeBetweenP2s.json
@@ -1,0 +1,964 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 5,
+  "iteration": 1667134128654,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 681,
+      "panels": [
+        {
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "points",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineStyle": {
+                  "dash": [
+                    0,
+                    10
+                  ],
+                  "fill": "dot"
+                },
+                "lineWidth": 1,
+                "pointSize": 10,
+                "scaleDistribution": {
+                  "log": 2,
+                  "type": "log"
+                },
+                "showPoints": "always",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "line"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 3600
+                  },
+                  {
+                    "color": "red",
+                    "value": 7200
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byFrameRefID",
+                  "options": "Unprotected"
+                },
+                "properties": [
+                  {
+                    "id": "custom.drawStyle",
+                    "value": "bars"
+                  },
+                  {
+                    "id": "custom.pointSize",
+                    "value": 1
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 1
+                  },
+                  {
+                    "id": "custom.lineStyle",
+                    "value": {
+                      "fill": "solid"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 1
+          },
+          "id": 682,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "8.4.3",
+          "repeat": "appliance",
+          "repeatDirection": "v",
+          "targets": [
+            {
+              "alias": "$tag_filer_title.TBP2",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "PB6B4F2F1C736D27A"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "filer_title"
+                  ],
+                  "type": "tag"
+                }
+              ],
+              "measurement": "gfa_data",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT elapsed(\"lock_duration\", 1s) FROM \"gfa_data\" WHERE (\"lock_state\" = 'RELEASED' AND \"lock_phase\" = 'P2') AND $timeFilter GROUP BY \"filer_title\"",
+              "rawQuery": false,
+              "refId": "TBP2",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "lock_duration"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [
+                      "1s"
+                    ],
+                    "type": "elapsed"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "lock_state",
+                  "operator": "=",
+                  "value": "RELEASED"
+                },
+                {
+                  "condition": "AND",
+                  "key": "lock_phase",
+                  "operator": "=",
+                  "value": "P2"
+                },
+                {
+                  "condition": "AND",
+                  "key": "filer_title",
+                  "operator": "=~",
+                  "value": "/^$appliance$/"
+                }
+              ]
+            },
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "PB6B4F2F1C736D27A"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "5m"
+                  ],
+                  "type": "time"
+                }
+              ],
+              "hide": false,
+              "measurement": "gfa_data",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "Unprotected",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "oldest_unprotected_data"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "sum"
+                  },
+                  {
+                    "params": [
+                      "oldest_unprotected_data"
+                    ],
+                    "type": "alias"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "filer_title",
+                  "operator": "=~",
+                  "value": "/^$appliance$/"
+                }
+              ]
+            }
+          ],
+          "title": "$appliance | Time between P2",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Time Between P2 with Unprotected Data",
+      "type": "row"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 427,
+      "panels": [],
+      "title": "Time between P2s, All appliances",
+      "type": "row"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 2,
+            "pointSize": 7,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "log"
+            },
+            "showPoints": "always",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 3600
+              },
+              {
+                "color": "red",
+                "value": 7200
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 15,
+        "w": 24,
+        "x": 0,
+        "y": 2
+      },
+      "id": 629,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.4.3",
+      "targets": [
+        {
+          "alias": "$tag_filer_title",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "PB6B4F2F1C736D27A"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "filer_title"
+              ],
+              "type": "tag"
+            }
+          ],
+          "measurement": "gfa_data",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT elapsed(\"lock_duration\", 1s) FROM \"gfa_data\" WHERE (\"lock_state\" = 'RELEASED' AND \"lock_phase\" = 'P2') AND $timeFilter GROUP BY \"filer_title\"",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "lock_duration"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "1s"
+                ],
+                "type": "elapsed"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "lock_state",
+              "operator": "=",
+              "value": "RELEASED"
+            },
+            {
+              "condition": "AND",
+              "key": "lock_phase",
+              "operator": "=",
+              "value": "P2"
+            },
+            {
+              "condition": "AND",
+              "key": "volume_title",
+              "operator": "=~",
+              "value": "/^$volume$/"
+            }
+          ]
+        }
+      ],
+      "title": "Time between P2",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 600,
+      "panels": [],
+      "title": "Time between P2 with write event count",
+      "type": "row"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "blue",
+            "mode": "fixed"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "points",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 7,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "always",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 3600
+              },
+              {
+                "color": "red",
+                "value": 7200
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "PropWrites"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-purple",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "unit",
+                "value": "none"
+              },
+              {
+                "id": "custom.drawStyle",
+                "value": "bars"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 24
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              },
+              {
+                "id": "custom.thresholdsStyle",
+                "value": {
+                  "mode": "off"
+                }
+              },
+              {
+                "id": "custom.axisLabel",
+                "value": "Write Events"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "id": 598,
+      "maxPerRow": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.4.3",
+      "repeat": "appliance",
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "alias": "$col",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "PB6B4F2F1C736D27A"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "filer_title"
+              ],
+              "type": "tag"
+            }
+          ],
+          "measurement": "gfa_data",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT elapsed(\"lock_duration\", 1s) FROM \"gfa_data\" WHERE (\"lock_state\" = 'RELEASED' AND \"lock_phase\" = 'P2') AND $timeFilter GROUP BY \"filer_title\"",
+          "rawQuery": false,
+          "refId": "TBP2",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "lock_duration"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "1s"
+                ],
+                "type": "elapsed"
+              },
+              {
+                "params": [
+                  "SInce last P2"
+                ],
+                "type": "alias"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "lock_state",
+              "operator": "=",
+              "value": "RELEASED"
+            },
+            {
+              "condition": "AND",
+              "key": "lock_phase",
+              "operator": "=",
+              "value": "P2"
+            },
+            {
+              "condition": "AND",
+              "key": "filer_title",
+              "operator": "=~",
+              "value": "/^$appliance$/"
+            }
+          ]
+        },
+        {
+          "alias": "$col",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "PB6B4F2F1C736D27A"
+          },
+          "groupBy": [],
+          "hide": false,
+          "measurement": "gfa_data",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "PropWrites",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "data_protected"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [
+                  "Write events"
+                ],
+                "type": "alias"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "filer_title",
+              "operator": "=~",
+              "value": "/^$appliance$/"
+            }
+          ]
+        }
+      ],
+      "title": "$appliance",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 170
+      },
+      "id": 631,
+      "panels": [
+        {
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "blue",
+                "mode": "fixed"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "bars",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 7,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "line"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 3600
+                  },
+                  {
+                    "color": "red",
+                    "value": 7200
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byFrameRefID",
+                  "options": "PropWrites"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "dark-purple",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "auto"
+                  },
+                  {
+                    "id": "unit",
+                    "value": "s"
+                  },
+                  {
+                    "id": "custom.drawStyle",
+                    "value": "bars"
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 39
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
+                  },
+                  {
+                    "id": "custom.thresholdsStyle",
+                    "value": {
+                      "mode": "off"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 27
+          },
+          "id": 633,
+          "maxPerRow": 2,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "8.4.3",
+          "repeat": "appliance",
+          "repeatDirection": "h",
+          "targets": [
+            {
+              "alias": "$col",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "PB6B4F2F1C736D27A"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "filer_title"
+                  ],
+                  "type": "tag"
+                }
+              ],
+              "measurement": "gfa_data",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT elapsed(\"lock_duration\", 1s) FROM \"gfa_data\" WHERE (\"lock_state\" = 'RELEASED' AND \"lock_phase\" = 'P2') AND $timeFilter GROUP BY \"filer_title\"",
+              "rawQuery": false,
+              "refId": "TBP2",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "lock_duration"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [
+                      "1s"
+                    ],
+                    "type": "elapsed"
+                  },
+                  {
+                    "params": [
+                      "SInce last P2"
+                    ],
+                    "type": "alias"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "lock_state",
+                  "operator": "=",
+                  "value": "RELEASED"
+                },
+                {
+                  "condition": "AND",
+                  "key": "lock_phase",
+                  "operator": "=",
+                  "value": "P2"
+                },
+                {
+                  "condition": "AND",
+                  "key": "filer_title",
+                  "operator": "=~",
+                  "value": "/^$appliance$/"
+                }
+              ]
+            },
+            {
+              "alias": "$col",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "PB6B4F2F1C736D27A"
+              },
+              "groupBy": [],
+              "hide": false,
+              "measurement": "gfa_data",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "PropWrites",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "prop_seconds"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [
+                      "Propagation"
+                    ],
+                    "type": "alias"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "filer_title",
+                  "operator": "=~",
+                  "value": "/^$appliance$/"
+                }
+              ]
+            }
+          ],
+          "title": "$appliance",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Time between P2 with propagation times",
+      "type": "row"
+    }
+  ],
+  "refresh": "5m",
+  "schemaVersion": 35,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "SGS-ONE_MASTERS",
+          "value": "SGS-ONE_MASTERS"
+        },
+        "definition": "SELECT distinct(volume_title) FROM (\nSELECT * \nFROM \"gfa_data\" \nWHERE $timeFilter \n)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Volume",
+        "multi": false,
+        "name": "volume",
+        "options": [],
+        "query": "SELECT distinct(volume_title) FROM (\nSELECT * \nFROM \"gfa_data\" \nWHERE $timeFilter \n)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "definition": "SELECT distinct(filer_title) FROM (\nSELECT * \nFROM \"gfa_data\" \nWHERE $timeFilter \n)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Appliances",
+        "multi": true,
+        "name": "appliance",
+        "options": [],
+        "query": "SELECT distinct(filer_title) FROM (\nSELECT * \nFROM \"gfa_data\" \nWHERE $timeFilter \n)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 5,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "GFA :: Time Between P2s",
+  "uid": "c20Yytsnz",
+  "version": 11,
+  "weekStart": ""
+}


### PR DESCRIPTION
This adds a new GFA dashboard to that shows various metrics around the time between P2 (metadata) pushes.

<img width="1857" alt="Screen Shot 2022-11-02 at 11 54 47 AM" src="https://user-images.githubusercontent.com/75635996/199538095-9cf31440-d148-4467-8597-42f9c307d0ed.png">
